### PR TITLE
LO-2261: Handle FHIR Datetimes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.lifeomic</groupId>
     <artifactId>fhirlib</artifactId>
-    <version>0.3.8</version>
+    <version>0.4.0</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
-            <version>2.11.0</version>
+            <version>2.11.8</version>
         </dependency>
         <dependency>
             <groupId>org.scalactic</groupId>

--- a/src/main/scala/com/lifeomic/fhirlib/v3/DateUtils.scala
+++ b/src/main/scala/com/lifeomic/fhirlib/v3/DateUtils.scala
@@ -1,14 +1,13 @@
 package com.lifeomic.fhirlib.v3
 
-import java.time.LocalDateTime
+import java.time.{LocalDateTime, ZoneId, ZonedDateTime}
 import java.time.format.{DateTimeFormatter, DateTimeFormatterBuilder}
 import java.time.temporal.ChronoField
-import java.util.TimeZone
 import java.util.regex.Pattern
 
 object DateUtils {
 
-  private val regex = "(\\d{4}(-\\d{2}(-\\d{2}(T\\d{2}(:\\d{2}(:\\d{2}(Z|-\\d{2}:\\d{2})?)?)?)?)?)?)"
+  private val regex = "(\\d{4}(-\\d{2}(-\\d{2}(T\\d{2}(:\\d{2}(:\\d{2}(Z|[\\+|\\-]\\d{2}:\\d{2})?)?)?)?)?)?)"
 
   private val formatters: Array[DateTimeFormatter] = Array(
 
@@ -60,6 +59,8 @@ object DateUtils {
   /**
     * Parses a string into a local date time object.
     *
+    * Any date times will be stored in UTC.
+    *
     * This method follows the specification for the FHIR date time object. See
     * https://www.hl7.org/fhir/datatypes.html#dateTime
     *
@@ -87,7 +88,11 @@ object DateUtils {
 
     val formatter: DateTimeFormatter = formatters(i - 1)
 
-    Some(LocalDateTime.parse(s, formatter))
+    if (i < 7) {
+      Some(LocalDateTime.parse(s, formatter))
+    } else {
+      Some(ZonedDateTime.parse(s, formatter).withZoneSameInstant(ZoneId.of("UTC")).toLocalDateTime)
+    }
   }
 
 }

--- a/src/main/scala/com/lifeomic/fhirlib/v3/DateUtils.scala
+++ b/src/main/scala/com/lifeomic/fhirlib/v3/DateUtils.scala
@@ -8,9 +8,6 @@ import java.util.regex.Pattern
 
 object DateUtils {
 
-  // The server time zone should always be UTC
-  TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
-
   private val regex = "(\\d{4}(-\\d{2}(-\\d{2}(T\\d{2}(:\\d{2}(:\\d{2}(Z|-\\d{2}:\\d{2})?)?)?)?)?)?)"
 
   private val formatters: Array[DateTimeFormatter] = Array(
@@ -90,7 +87,6 @@ object DateUtils {
 
     val formatter: DateTimeFormatter = formatters(i - 1)
 
-    println(LocalDateTime.parse(s, formatter))
     Some(LocalDateTime.parse(s, formatter))
   }
 

--- a/src/main/scala/com/lifeomic/fhirlib/v3/DateUtils.scala
+++ b/src/main/scala/com/lifeomic/fhirlib/v3/DateUtils.scala
@@ -1,0 +1,97 @@
+package com.lifeomic.fhirlib.v3
+
+import java.time.LocalDateTime
+import java.time.format.{DateTimeFormatter, DateTimeFormatterBuilder}
+import java.time.temporal.ChronoField
+import java.util.TimeZone
+import java.util.regex.Pattern
+
+object DateUtils {
+
+  // The server time zone should always be UTC
+  TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+
+  private val regex = "(\\d{4}(-\\d{2}(-\\d{2}(T\\d{2}(:\\d{2}(:\\d{2}(Z|-\\d{2}:\\d{2})?)?)?)?)?)?)"
+
+  private val formatters: Array[DateTimeFormatter] = Array(
+
+    new DateTimeFormatterBuilder()
+      .appendPattern("yyyy")
+      .parseDefaulting(ChronoField.MONTH_OF_YEAR, 1)
+      .parseDefaulting(ChronoField.DAY_OF_MONTH, 1)
+      .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
+      .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
+      .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0)
+      .parseDefaulting(ChronoField.MILLI_OF_SECOND, 0)
+      .toFormatter(),
+    new DateTimeFormatterBuilder()
+      .appendPattern("yyyy-MM")
+      .parseDefaulting(ChronoField.DAY_OF_MONTH, 1)
+      .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
+      .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
+      .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0)
+      .parseDefaulting(ChronoField.MILLI_OF_SECOND, 0)
+      .toFormatter(),
+    new DateTimeFormatterBuilder()
+      .appendPattern("yyyy-MM-dd")
+      .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
+      .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
+      .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0)
+      .parseDefaulting(ChronoField.MILLI_OF_SECOND, 0)
+      .toFormatter(),
+    new DateTimeFormatterBuilder()
+      .appendPattern("yyyy-MM-dd'T'HH")
+      .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
+      .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0)
+      .parseDefaulting(ChronoField.MILLI_OF_SECOND, 0)
+      .toFormatter(),
+    new DateTimeFormatterBuilder()
+      .appendPattern("yyyy-MM-dd'T'HH:mm")
+      .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0)
+      .parseDefaulting(ChronoField.MILLI_OF_SECOND, 0)
+      .toFormatter(),
+    new DateTimeFormatterBuilder()
+      .appendPattern("yyyy-MM-dd'T'HH:mm:ss")
+      .parseDefaulting(ChronoField.MILLI_OF_SECOND, 0)
+      .toFormatter(),
+    new DateTimeFormatterBuilder()
+      .appendPattern("yyyy-MM-dd'T'HH:mm:ssXXXXX")
+      .parseDefaulting(ChronoField.MILLI_OF_SECOND, 0)
+      .toFormatter()
+  )
+
+  /**
+    * Parses a string into a local date time object.
+    *
+    * This method follows the specification for the FHIR date time object. See
+    * https://www.hl7.org/fhir/datatypes.html#dateTime
+    *
+    * @param s a string to parse
+    * @return a local date time
+    */
+  def parseLocalDateTime(s: String): Option[LocalDateTime] = {
+
+    val pattern = Pattern.compile(regex)
+    val matcher = pattern.matcher(s)
+
+    if (!matcher.find()) {
+      return None
+    }
+
+    // scan groups to count non-null matches
+    var i: Int = 0
+    while (i < matcher.groupCount() && matcher.group(i + 1) != null) {
+      i += 1
+    }
+
+    if (i < 1 || i > 7) {
+      throw new RuntimeException("unable to determine format of datetime")
+    }
+
+    val formatter: DateTimeFormatter = formatters(i - 1)
+
+    println(LocalDateTime.parse(s, formatter))
+    Some(LocalDateTime.parse(s, formatter))
+  }
+
+}

--- a/src/main/scala/com/lifeomic/fhirlib/v3/Deserializer.scala
+++ b/src/main/scala/com/lifeomic/fhirlib/v3/Deserializer.scala
@@ -1,9 +1,10 @@
 package com.lifeomic.fhirlib.v3
 
+import java.time.ZoneId
+
 import com.lifeomic.fhirlib.v3.datatypes._
 import com.lifeomic.fhirlib.v3.resources.{Resource, _}
-import org.joda.time.format.ISODateTimeFormat
-import org.joda.time.{DateTime, DateTimeZone}
+import org.joda.time.{DateTime, DateTimeZone, LocalDateTime}
 import org.json4s.ext.EnumNameSerializer
 import org.json4s.jackson.Serialization.read
 import org.json4s.{CustomSerializer, DefaultFormats, Formats, JString, _}
@@ -11,12 +12,10 @@ import org.json4s.{CustomSerializer, DefaultFormats, Formats, JString, _}
 case object DateTimeSerializer extends CustomSerializer[DateTime](format => ( {
   case JString(s) => {
     try {
-      val parser = ISODateTimeFormat.dateTimeParser().withOffsetParsed()
-      parser.parseDateTime(s)
+      DateUtils.parseLocalDateTime(s).map(d => new LocalDateTime(d.atZone(ZoneId.systemDefault()).toInstant.toEpochMilli).toDateTime).orNull
     } catch {
       case _: Throwable => null
     }
-
   }
   case _ => null
 }, {

--- a/src/main/scala/com/lifeomic/fhirlib/v3/Deserializer.scala
+++ b/src/main/scala/com/lifeomic/fhirlib/v3/Deserializer.scala
@@ -1,7 +1,7 @@
 package com.lifeomic.fhirlib.v3
 
 import java.time.format.DateTimeFormatter
-import java.time.{LocalDateTime}
+import java.time.{LocalDateTime, ZoneId, ZonedDateTime}
 
 import com.lifeomic.fhirlib.v3.datatypes._
 import com.lifeomic.fhirlib.v3.resources.{Resource, _}
@@ -19,7 +19,7 @@ case object DateTimeSerializer extends CustomSerializer[LocalDateTime](format =>
   }
   case _ => null
 }, {
-  case d: LocalDateTime => JString(d.format(DateTimeFormatter.ISO_DATE_TIME))
+  case d: LocalDateTime => JString(ZonedDateTime.of(d, ZoneId.of("UTC")).format(DateTimeFormatter.ISO_DATE_TIME))
 }
 ))
 

--- a/src/main/scala/com/lifeomic/fhirlib/v3/Deserializer.scala
+++ b/src/main/scala/com/lifeomic/fhirlib/v3/Deserializer.scala
@@ -1,25 +1,25 @@
 package com.lifeomic.fhirlib.v3
 
-import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.{LocalDateTime}
 
 import com.lifeomic.fhirlib.v3.datatypes._
 import com.lifeomic.fhirlib.v3.resources.{Resource, _}
-import org.joda.time.{DateTime, DateTimeZone, LocalDateTime}
 import org.json4s.ext.EnumNameSerializer
 import org.json4s.jackson.Serialization.read
 import org.json4s.{CustomSerializer, DefaultFormats, Formats, JString, _}
 
-case object DateTimeSerializer extends CustomSerializer[DateTime](format => ( {
+case object DateTimeSerializer extends CustomSerializer[LocalDateTime](format => ( {
   case JString(s) => {
     try {
-      DateUtils.parseLocalDateTime(s).map(d => new LocalDateTime(d.atZone(ZoneId.systemDefault()).toInstant.toEpochMilli).toDateTime).orNull
+      DateUtils.parseLocalDateTime(s).orNull
     } catch {
       case _: Throwable => null
     }
   }
   case _ => null
 }, {
-  case d: DateTime => JString(format.dateFormat.format(d.toDate))
+  case d: LocalDateTime => JString(d.format(DateTimeFormatter.ISO_DATE_TIME))
 }
 ))
 
@@ -58,7 +58,6 @@ object ResourceSerializer extends Serializer[Resource] {
 
 object Deserializer {
   def loadFhirResource(jsonString: String): Resource = {
-    DateTimeZone.setDefault(DateTimeZone.UTC);
 
     implicit val formats: Formats = DefaultFormats +
       ResourceSerializer +

--- a/src/main/scala/com/lifeomic/fhirlib/v3/datatypes/Annotation.scala
+++ b/src/main/scala/com/lifeomic/fhirlib/v3/datatypes/Annotation.scala
@@ -1,8 +1,8 @@
 package com.lifeomic.fhirlib.v3.datatypes
 
-import org.joda.time.DateTime
+import java.time.LocalDateTime
 
 class Annotation(val authorReference: Option[Reference],
                  val authorString: Option[String],
-                 val time: Option[DateTime],
+                 val time: Option[LocalDateTime],
                  val text: Option[String])

--- a/src/main/scala/com/lifeomic/fhirlib/v3/datatypes/Attachment.scala
+++ b/src/main/scala/com/lifeomic/fhirlib/v3/datatypes/Attachment.scala
@@ -1,7 +1,8 @@
 package com.lifeomic.fhirlib.v3.datatypes
 
+import java.time.LocalDateTime
+
 import com.google.common.primitives.UnsignedInteger
-import org.joda.time.DateTime
 
 class Attachment(val contentType: Option[String],
                  val language: Option[String],
@@ -10,6 +11,6 @@ class Attachment(val contentType: Option[String],
                  val size: Option[UnsignedInteger],
                  val hash: Option[String],
                  val title: Option[String],
-                 val creation: Option[DateTime]) {
+                 val creation: Option[LocalDateTime]) {
 
 }

--- a/src/main/scala/com/lifeomic/fhirlib/v3/datatypes/Extension.scala
+++ b/src/main/scala/com/lifeomic/fhirlib/v3/datatypes/Extension.scala
@@ -2,17 +2,17 @@ package com.lifeomic.fhirlib.v3.datatypes
 
 
 import java.net.URI
+import java.time.LocalDateTime
 
 import com.lifeomic.fhirlib.v3.resources.Schedule
-import org.joda.time.DateTime
 
 class Extension(val url: Option[String],
                 val extension: Option[List[Extension]],
                 val valueInteger: Option[Int],
                 val valueDecimal: Option[Double],
-                val valueDateTime: Option[DateTime],
-                val valueDate: Option[DateTime],
-                val valueInstant: Option[DateTime],
+                val valueDateTime: Option[LocalDateTime],
+                val valueDate: Option[LocalDateTime],
+                val valueInstant: Option[LocalDateTime],
                 val valueString: Option[String],
                 val valueUri: Option[URI],
                 val valueBoolean: Option[Boolean],

--- a/src/main/scala/com/lifeomic/fhirlib/v3/datatypes/Meta.scala
+++ b/src/main/scala/com/lifeomic/fhirlib/v3/datatypes/Meta.scala
@@ -1,9 +1,9 @@
 package com.lifeomic.fhirlib.v3.datatypes
 
-import org.joda.time.DateTime
+import java.time.LocalDateTime
 
 class Meta(val versionId: Option[String],
-           val lastUdpated: Option[DateTime],
+           val lastUdpated: Option[LocalDateTime],
            val profile: Option[List[String]],
            val security: Option[List[Coding]],
            val tag: Option[List[Coding]]) {

--- a/src/main/scala/com/lifeomic/fhirlib/v3/datatypes/Period.scala
+++ b/src/main/scala/com/lifeomic/fhirlib/v3/datatypes/Period.scala
@@ -1,7 +1,7 @@
 package com.lifeomic.fhirlib.v3.datatypes
 
-import org.joda.time.DateTime
+import java.time.LocalDateTime
 
-class Period(val start: Option[DateTime], val end: Option[DateTime]) {
+class Period(val start: Option[LocalDateTime], val end: Option[LocalDateTime]) {
 
 }

--- a/src/main/scala/com/lifeomic/fhirlib/v3/datatypes/Timing.scala
+++ b/src/main/scala/com/lifeomic/fhirlib/v3/datatypes/Timing.scala
@@ -1,11 +1,11 @@
 package com.lifeomic.fhirlib.v3.datatypes
 
-import org.joda.time.{DateTime, LocalTime}
-
 object DayOfWeek extends Enumeration {
   type DayOfWeek = Value
   val mon, tue, wed, thu, fri, sat, sun = Value
 }
+
+import java.time.{LocalDateTime, LocalTime}
 
 import com.lifeomic.fhirlib.v3.datatypes.DayOfWeek._
 
@@ -34,7 +34,7 @@ class TimingRepeat(val boundsDuration: Option[Quantity],
                    val when: Option[List[String]],
                    val offset: Option[String])
 
-class Timing(val event: Option[List[DateTime]],
+class Timing(val event: Option[List[LocalDateTime]],
              val repeat: Option[TimingRepeat],
              val code: Option[CodeableConcept]) {
 

--- a/src/main/scala/com/lifeomic/fhirlib/v3/resources/Condition.scala
+++ b/src/main/scala/com/lifeomic/fhirlib/v3/resources/Condition.scala
@@ -1,7 +1,8 @@
 package com.lifeomic.fhirlib.v3.resources
 
+import java.time.LocalDateTime
+
 import com.lifeomic.fhirlib.v3.datatypes._
-import org.joda.time.DateTime
 
 object ClinicalStatus extends Enumeration {
   type ClinicalStatus = Value
@@ -33,17 +34,17 @@ class Condition(override val id: Option[String],
                 val bodySite: Option[List[CodeableConcept]],
                 val subject: Option[Reference],
                 val context: Option[Reference],
-                val onsetDateTime: Option[DateTime],
-                val onsetDate: Option[DateTime],
+                val onsetDateTime: Option[LocalDateTime],
+                val onsetDate: Option[LocalDateTime],
                 val onsetPeriod: Option[Period],
                 val onsetRange: Option[Range],
                 val onsetString: Option[String],
-                val abatementDateTime: Option[DateTime],
+                val abatementDateTime: Option[LocalDateTime],
                 val abatementAge: Option[Quantity],
                 val abatementBoolean: Option[Boolean],
                 val abatementRange: Option[Range],
                 val abatementString: Option[String],
-                val assertedDate: Option[DateTime],
+                val assertedDate: Option[LocalDateTime],
                 val asserter: Option[Reference],
                 val stage: Option[ConditionStage],
                 val evidence: Option[List[ConditionEvidence]],

--- a/src/main/scala/com/lifeomic/fhirlib/v3/resources/Medication.scala
+++ b/src/main/scala/com/lifeomic/fhirlib/v3/resources/Medication.scala
@@ -1,7 +1,8 @@
 package com.lifeomic.fhirlib.v3.resources
 
+import java.time.LocalDateTime
+
 import com.lifeomic.fhirlib.v3.datatypes._
-import org.joda.time.DateTime
 
 object MedicationStatus extends Enumeration {
   type MedicationStatus = Value
@@ -18,7 +19,7 @@ class PackageContent(val itemCodeableConcept: Option[CodeableConcept],
                      val amount: Option[Quantity])
 
 class PackageBatch(val lotNumber: Option[String],
-                   val expirationDate: Option[DateTime])
+                   val expirationDate: Option[LocalDateTime])
 
 class MedicationPackage(val container: Option[CodeableConcept],
                         val content: Option[List[PackageContent]],

--- a/src/main/scala/com/lifeomic/fhirlib/v3/resources/MedicationAdministration.scala
+++ b/src/main/scala/com/lifeomic/fhirlib/v3/resources/MedicationAdministration.scala
@@ -1,7 +1,8 @@
 package com.lifeomic.fhirlib.v3.resources
 
+import java.time.LocalDateTime
+
 import com.lifeomic.fhirlib.v3.datatypes._
-import org.joda.time.DateTime
 
 object MedicationAdministrationStatus extends Enumeration {
   type MedicationAdministrationStatus = Value
@@ -26,7 +27,7 @@ class MedicationAdministration(override val id: Option[String],
                                val subject: Option[Reference],
                                val context: Option[Reference],
                                val supportingInformation: Option[List[Reference]],
-                               val effectiveDateTime: Option[DateTime],
+                               val effectiveDateTime: Option[LocalDateTime],
                                val effectivePeriod: Option[Period],
                                val performer: Option[Performer],
                                val notGiven: Option[Boolean],

--- a/src/main/scala/com/lifeomic/fhirlib/v3/resources/MedicationRequest.scala
+++ b/src/main/scala/com/lifeomic/fhirlib/v3/resources/MedicationRequest.scala
@@ -1,7 +1,8 @@
 package com.lifeomic.fhirlib.v3.resources
 
+import java.time.LocalDateTime
+
 import com.lifeomic.fhirlib.v3.datatypes._
-import org.joda.time.DateTime
 
 object MedicationRequestStatus extends Enumeration {
   type MedicationRequestStatus = Value
@@ -48,7 +49,7 @@ class MedicationRequest(override val id: Option[String],
                         val subject: Option[Reference],
                         val context: Option[Reference],
                         val supportingInformation: Option[Reference],
-                        val authoredOn: Option[DateTime],
+                        val authoredOn: Option[LocalDateTime],
                         val requester: Option[Requester],
                         val recorder: Option[Reference],
                         val reasonCode: Option[List[CodeableConcept]],

--- a/src/main/scala/com/lifeomic/fhirlib/v3/resources/MedicationStatement.scala
+++ b/src/main/scala/com/lifeomic/fhirlib/v3/resources/MedicationStatement.scala
@@ -1,7 +1,8 @@
 package com.lifeomic.fhirlib.v3.resources
 
+import java.time.LocalDateTime
+
 import com.lifeomic.fhirlib.v3.datatypes._
-import org.joda.time.DateTime
 
 object MedicationStatementStatus extends Enumeration {
   type MedicationStatementStatus = Value
@@ -27,9 +28,9 @@ class MedicationStatement(override val id: Option[String],
                           val category: Option[CodeableConcept],
                           val medicationCodeableConcept: Option[CodeableConcept],
                           val medicationReference: Option[Reference],
-                          val effectiveDateTime: Option[DateTime],
+                          val effectiveDateTime: Option[LocalDateTime],
                           val effectivePeriod: Option[Period],
-                          val dateAsserted: Option[DateTime],
+                          val dateAsserted: Option[LocalDateTime],
                           val informationSource: Option[Reference],
                           val subject: Option[Reference],
                           val derivedFrom: Option[List[Reference]],

--- a/src/main/scala/com/lifeomic/fhirlib/v3/resources/Observation.scala
+++ b/src/main/scala/com/lifeomic/fhirlib/v3/resources/Observation.scala
@@ -1,7 +1,8 @@
 package com.lifeomic.fhirlib.v3.resources
 
+import java.time.{LocalDateTime, LocalTime}
+
 import com.lifeomic.fhirlib.v3.datatypes._
-import org.joda.time.{DateTime, LocalTime}
 
 object ObservationStatus extends Enumeration {
   type ObservationStatus = Value
@@ -34,7 +35,7 @@ class ObservationComponent(val code: CodeableConcept,
                            val valueSampledData: Option[SampledData],
                            val valueAttachment: Option[Attachment],
                            val valueTime: Option[LocalTime],
-                           val valueDateTime: Option[DateTime],
+                           val valueDateTime: Option[LocalDateTime],
                            val valuePeriod: Option[Period],
                            val dataAbsentReason: Option[CodeableConcept],
                            val interpretation: Option[CodeableConcept],
@@ -51,9 +52,9 @@ class Observation(override val id: Option[String],
                   val code: CodeableConcept,
                   val subject: Option[Reference],
                   val context: Option[Reference],
-                  val effectiveDateTime: Option[DateTime],
+                  val effectiveDateTime: Option[LocalDateTime],
                   val effectivePeriod: Option[Period],
-                  val issued: Option[DateTime],
+                  val issued: Option[LocalDateTime],
                   val performer: Option[List[Reference]],
                   val valueQuantity: Option[Quantity],
                   val valueCodeableConcept: Option[CodeableConcept],
@@ -64,7 +65,7 @@ class Observation(override val id: Option[String],
                   val valueSampledData: Option[SampledData],
                   val valueAttachment: Option[Attachment],
                   val valueTime: Option[LocalTime],
-                  val valueDateTime: Option[DateTime],
+                  val valueDateTime: Option[LocalDateTime],
                   val valuePeriod: Option[Period],
                   val dataAbsentReason: Option[CodeableConcept],
                   val interpretation: Option[CodeableConcept],

--- a/src/main/scala/com/lifeomic/fhirlib/v3/resources/Patient.scala
+++ b/src/main/scala/com/lifeomic/fhirlib/v3/resources/Patient.scala
@@ -1,7 +1,9 @@
 package com.lifeomic.fhirlib.v3.resources
 
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+
 import com.lifeomic.fhirlib.v3.datatypes._
-import org.joda.time.{DateTime, Years}
 
 import scala.collection.mutable.ListBuffer
 
@@ -46,9 +48,9 @@ class Patient(override val id: Option[String],
               val name: Option[List[HumanName]],
               val telecom: Option[List[ContactPoint]],
               val gender: Option[Gender],
-              val birthDate: Option[DateTime],
+              val birthDate: Option[LocalDateTime],
               val deceasedBoolean: Option[Boolean],
-              val deceasedDateTime: Option[DateTime],
+              val deceasedDateTime: Option[LocalDateTime],
               val address: Option[List[Address]],
               val maritalStatus: Option[CodeableConcept],
               val multipleBirthsBoolean: Option[Boolean],
@@ -106,6 +108,6 @@ class Patient(override val id: Option[String],
     if (birthDate.isEmpty) {
       return None
     }
-    return Some(Years.yearsBetween(birthDate.get, DateTime.now).getYears)
+    return Some(ChronoUnit.YEARS.between(birthDate.get, LocalDateTime.now).toInt)
   }
 }

--- a/src/main/scala/com/lifeomic/fhirlib/v3/resources/Procedure.scala
+++ b/src/main/scala/com/lifeomic/fhirlib/v3/resources/Procedure.scala
@@ -1,7 +1,8 @@
 package com.lifeomic.fhirlib.v3.resources
 
+import java.time.LocalDateTime
+
 import com.lifeomic.fhirlib.v3.datatypes._
-import org.joda.time.DateTime
 
 object ProcedureStatus extends Enumeration {
   type ProcedureStatus = Value
@@ -30,7 +31,7 @@ class Procedure(override val id: Option[String],
                 val code: Option[CodeableConcept],
                 val subject: Option[Reference],
                 val context: Option[Reference],
-                val performedDateTime: Option[DateTime],
+                val performedDateTime: Option[LocalDateTime],
                 val performedPeriod: Option[Period],
                 val performer: Option[ProcedurePerformer],
                 val location: Option[Reference],

--- a/src/main/scala/com/lifeomic/fhirlib/v3/resources/Specimen.scala
+++ b/src/main/scala/com/lifeomic/fhirlib/v3/resources/Specimen.scala
@@ -1,7 +1,8 @@
 package com.lifeomic.fhirlib.v3.resources
 
+import java.time.LocalDateTime
+
 import com.lifeomic.fhirlib.v3.datatypes._
-import org.joda.time.DateTime
 
 import scala.collection.mutable.ListBuffer
 
@@ -11,7 +12,7 @@ object Specimen_Status extends Enumeration {
 }
 
 class Collection(val collector: Option[Reference],
-                 val collectedDateTime: Option[DateTime],
+                 val collectedDateTime: Option[LocalDateTime],
                  val collectedPeriod: Option[Period],
                  val quantity: Option[Quantity],
                  val method: Option[CodeableConcept],
@@ -20,7 +21,7 @@ class Collection(val collector: Option[Reference],
 class Processing(val description: Option[String],
                  val procedure: Option[CodeableConcept],
                  val additive: Option[List[Reference]],
-                 val timeDateTime: Option[DateTime],
+                 val timeDateTime: Option[LocalDateTime],
                  val timePeriod: Option[Period])
 
 class Container(val identifier: Option[List[Identifier]],
@@ -40,7 +41,7 @@ class Specimen(override val id: Option[String],
                val status: Option[String],
                val `type`: Option[CodeableConcept],
                val subject: Option[Reference],
-               val receivedTime: Option[DateTime],
+               val receivedTime: Option[LocalDateTime],
                val parent: Option[List[Reference]],
                val request: Option[List[Reference]],
                val collection: Option[Collection],

--- a/src/test/scala/com/lifeomic/fhirlib/v3/TestSuite.scala
+++ b/src/test/scala/com/lifeomic/fhirlib/v3/TestSuite.scala
@@ -1,6 +1,9 @@
 package com.lifeomic.fhirlib.v3
 
+import java.time.format.DateTimeFormatter
+
 import com.lifeomic.fhirlib.v3.resources._
+import org.junit.Assert
 import org.junit.runner.RunWith
 import org.scalactic.TolerantNumerics
 import org.scalatest.FunSuite
@@ -36,7 +39,7 @@ class TestSuite extends FunSuite {
     assert(resource.clinicalStatus.get.toString == ClinicalStatus.active.toString)
     assert(resource.verificationStatus.get == "confirmed")
     assert(resource.subject.get.reference.get == "Patient/example")
-    assert(resource.onsetDateTime.get.year().get() == 2012)
+    assert(resource.onsetDateTime.map(d => d.getYear).getOrElse(Assert.fail()) == 2012)
   }
 
   test("Test MedicationAdministration") {
@@ -78,7 +81,7 @@ class TestSuite extends FunSuite {
     assert(resource.code.get.coding.get.head.display.get == "Appendectomy (Procedure)")
     assert(resource.code.get.text.get == "Appendectomy")
     assert(resource.subject.get.getId.get == "example")
-    assert(resource.performedDateTime.get.toString("yyyy-MM-dd") == "2013-04-05")
+    assert(resource.performedDateTime.map(d => d.format(DateTimeFormatter.ofPattern( "yyyy-MM-dd"))).getOrElse(Assert.fail()) == "2013-04-05")
     assert(resource.performedPeriod.isEmpty)
     assert(resource.note.get.head.text.get == "Routine Appendectomy. Appendix was inflamed and in retro-caecal position")
   }
@@ -127,9 +130,9 @@ class TestSuite extends FunSuite {
     val patient = Deserializer.loadFhirResource(json).asInstanceOf[Patient]
 
     assert(patient.gender.orNull == Gender.female)
-    assert(patient.birthDate.orNull.year().get() == 1993)
-    assert(patient.birthDate.orNull.monthOfYear().get() == 5)
-    assert(patient.birthDate.orNull.dayOfMonth().get() == 7)
+    assert(patient.birthDate.map(d => d.getYear).getOrElse(Assert.fail()) == 1993)
+    assert(patient.birthDate.map(d => d.getMonthValue).getOrElse(Assert.fail()) == 5)
+    assert(patient.birthDate.map(d => d.getDayOfMonth).getOrElse(Assert.fail()) == 7)
     val uri = new java.net.URI(patient.meta.orNull.tag.get.head.system.get)
     assert(uri.getHost() == "lifeomic.com")
     assert(uri.getPath() == "/fhir/dataset")


### PR DESCRIPTION
This change fixes the FHIR date time parsing and migrates from joda-time to the 'java.time' package.