### PR TITLE
LO-3669: Upgrade json4s

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.lifeomic</groupId>
     <artifactId>fhirlib</artifactId>
-    <version>0.7.0</version>
+    <version>0.8.0</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -52,7 +52,7 @@
         <scala.major.version>2</scala.major.version>
         <scala.minor.version>11</scala.minor.version>
         <scala.patch.version>12</scala.patch.version>
-        <json4s.version>3.2.11</json4s.version>
+        <json4s.version>3.5.3</json4s.version>
     </properties>
 
     <dependencies>

--- a/src/main/scala/com/lifeomic/fhirlib/v3/Deserializer.scala
+++ b/src/main/scala/com/lifeomic/fhirlib/v3/Deserializer.scala
@@ -3,11 +3,12 @@ package com.lifeomic.fhirlib.v3
 import java.time.format.DateTimeFormatter
 import java.time.{LocalDateTime, ZoneId, ZonedDateTime}
 
+import com.fasterxml.jackson.databind.DeserializationFeature
 import com.lifeomic.fhirlib.v3.datatypes._
 import com.lifeomic.fhirlib.v3.resources.{Resource, _}
 import org.json4s.ext.EnumNameSerializer
 import org.json4s.jackson.Serialization.read
-import org.json4s.{CustomSerializer, DefaultFormats, Formats, JString, _}
+import org.json4s.{CustomSerializer, DefaultFormats, Formats, JString, JValue, TypeInfo, _}
 
 case object DateTimeSerializer extends CustomSerializer[LocalDateTime](format => ( {
   case JString(s) => {
@@ -45,7 +46,7 @@ object ResourceSerializer extends Serializer[Resource] {
           case "Specimen" => json.extract[Specimen]
 
           case resourceType: String => {
-            new Resource(s"${resourceType} Not Implemented", None, None, None, None, None)
+            new Resource(s"$resourceType Not Implemented", None, None, None, None, None)
           }
 
           case _ => {
@@ -60,12 +61,201 @@ object ResourceSerializer extends Serializer[Resource] {
   def serialize(implicit format: Formats): PartialFunction[Any, JValue] = Map()
 }
 
+object EmptyReferenceSerializer extends Serializer[Reference] {
+    private val ReferenceClass = classOf[Reference]
+
+    override def deserialize(implicit format: Formats): PartialFunction[(TypeInfo, JValue), Reference] = {
+        new PartialFunction[(TypeInfo, JValue), Reference] {
+
+            def isDefinedAt(infoValue: (TypeInfo, JValue)): Boolean = {
+                infoValue match {
+                    case (TypeInfo(ReferenceClass, _), json) => json match {
+                        case x: JArray => x.arr.isEmpty
+                        case _ => false
+                    }
+                    case _ => false
+                }
+            }
+
+            def apply(infoValue: (TypeInfo, JValue)) = {
+                new Reference(None, None, None)
+            }
+        }
+    }
+
+    override def serialize(implicit format: Formats): PartialFunction[Any, JValue] = Map()
+}
+
+object UnwrapStringSerializer extends Serializer[String] {
+    private val TargetClass = classOf[String]
+
+    override def deserialize(implicit format: Formats): PartialFunction[(TypeInfo, JValue), String] = {
+        new PartialFunction[(TypeInfo, JValue), String] {
+
+            def isDefinedAt(infoValue: (TypeInfo, JValue)): Boolean = {
+                infoValue match {
+                    case (TypeInfo(TargetClass, _), json) => json match {
+                        case x: JArray => x.arr.length == 1 && x.arr.head.isInstanceOf[JString]
+                        case _ => false
+                    }
+                    case _ => false
+                }
+            }
+
+            def apply(infoValue: (TypeInfo, JValue)) = {
+                infoValue._2 match {
+                    case x: JArray => x.arr.head match {
+                        case v: JString => v.s
+                        case _ => throw new MappingException(s"Nested value is not a $TargetClass")
+                    }
+                    case _ => throw new MappingException("Invalid type")
+                }
+            }
+        }
+    }
+
+    override def serialize(implicit format: Formats): PartialFunction[Any, JValue] = Map()
+}
+
+object UnwrapIntSerializer extends Serializer[Int] {
+    private val TargetClass = classOf[Int]
+
+    override def deserialize(implicit format: Formats): PartialFunction[(TypeInfo, JValue), Int] = {
+        new PartialFunction[(TypeInfo, JValue), Int] {
+
+            def isDefinedAt(infoValue: (TypeInfo, JValue)): Boolean = {
+                infoValue match {
+                    case (TypeInfo(TargetClass, _), json) => json match {
+                        case x: JArray => x.arr.length == 1 && x.arr.head.isInstanceOf[JInt]
+                        case _ => false
+                    }
+                    case _ => false
+                }
+            }
+
+            def apply(infoValue: (TypeInfo, JValue)) = {
+                infoValue._2 match {
+                    case x: JArray => x.arr.head match {
+                        case v: JInt => v.num.intValue()
+                        case _ => throw new MappingException(s"Nested value is not a $TargetClass")
+                    }
+                    case _ => throw new MappingException("Invalid type")
+                }
+            }
+        }
+    }
+
+    override def serialize(implicit format: Formats): PartialFunction[Any, JValue] = Map()
+}
+
+object UnwrapLongSerializer extends Serializer[Long] {
+    private val TargetClass = classOf[Long]
+
+    override def deserialize(implicit format: Formats): PartialFunction[(TypeInfo, JValue), Long] = {
+        new PartialFunction[(TypeInfo, JValue), Long] {
+
+            def isDefinedAt(infoValue: (TypeInfo, JValue)): Boolean = {
+                infoValue match {
+                    case (TypeInfo(TargetClass, _), json) => json match {
+                        case x: JArray => x.arr.length == 1 && x.arr.head.isInstanceOf[JLong]
+                        case _ => false
+                    }
+                    case _ => false
+                }
+            }
+
+            def apply(infoValue: (TypeInfo, JValue)) = {
+                infoValue._2 match {
+                    case x: JArray => x.arr.head match {
+                        case v: JLong => v.num
+                        case _ => throw new MappingException(s"Nested value is not a $TargetClass")
+                    }
+                    case _ => throw new MappingException("Invalid type")
+                }
+            }
+        }
+    }
+
+    override def serialize(implicit format: Formats): PartialFunction[Any, JValue] = Map()
+}
+
+object UnwrapDoubleSerializer extends Serializer[Double] {
+    private val TargetClass = classOf[Double]
+
+    override def deserialize(implicit format: Formats): PartialFunction[(TypeInfo, JValue), Double] = {
+        new PartialFunction[(TypeInfo, JValue), Double] {
+
+            def isDefinedAt(infoValue: (TypeInfo, JValue)): Boolean = {
+                infoValue match {
+                    case (TypeInfo(TargetClass, _), json) => json match {
+                        case x: JArray => x.arr.length == 1 && x.arr.head.isInstanceOf[JDouble]
+                        case _ => false
+                    }
+                    case _ => false
+                }
+            }
+
+            def apply(infoValue: (TypeInfo, JValue)) = {
+                infoValue._2 match {
+                    case x: JArray => x.arr.head match {
+                        case v: JDouble => v.num
+                        case _ => throw new MappingException(s"Nested value is not a $TargetClass")
+                    }
+                    case _ => throw new MappingException("Invalid type")
+                }
+            }
+        }
+    }
+
+    override def serialize(implicit format: Formats): PartialFunction[Any, JValue] = Map()
+}
+
+object UnwrapBooleanSerializer extends Serializer[Boolean] {
+    private val TargetClass = classOf[Boolean]
+
+    override def deserialize(implicit format: Formats): PartialFunction[(TypeInfo, JValue), Boolean] = {
+        new PartialFunction[(TypeInfo, JValue), Boolean] {
+
+            def isDefinedAt(infoValue: (TypeInfo, JValue)): Boolean = {
+                infoValue match {
+                    case (TypeInfo(TargetClass, _), json) => json match {
+                        case x: JArray => x.arr.length == 1 && x.arr.head.isInstanceOf[JBool]
+                        case _ => false
+                    }
+                    case _ => false
+                }
+            }
+
+            def apply(infoValue: (TypeInfo, JValue)) = {
+                infoValue._2 match {
+                    case x: JArray => x.arr.head match {
+                        case v: JBool => v.value
+                        case _ => throw new MappingException(s"Nested value is not a $TargetClass")
+                    }
+                    case _ => throw new MappingException("Invalid type")
+                }
+            }
+        }
+    }
+
+    override def serialize(implicit format: Formats): PartialFunction[Any, JValue] = Map()
+}
+
 object Deserializer {
+  org.json4s.jackson.JsonMethods.mapper.enable(DeserializationFeature.UNWRAP_SINGLE_VALUE_ARRAYS)
+
   def loadFhirResource(jsonString: String): Resource = {
 
     implicit val formats: Formats = DefaultFormats +
       ResourceSerializer +
       DateTimeSerializer +
+      EmptyReferenceSerializer +
+      UnwrapStringSerializer +
+      UnwrapIntSerializer +
+      UnwrapLongSerializer +
+      UnwrapDoubleSerializer +
+      UnwrapBooleanSerializer +
+      UnwrapStringSerializer +
       new EnumNameSerializer(Address_Use) +
       new EnumNameSerializer(Address_Type) +
       new EnumNameSerializer(ClinicalStatus) +

--- a/src/test/scala/com/lifeomic/fhirlib/v3/TestSuite.scala
+++ b/src/test/scala/com/lifeomic/fhirlib/v3/TestSuite.scala
@@ -27,6 +27,13 @@ class TestSuite extends FunSuite {
 
     assert(specimen.status.get == "available")
     assert(specimen.findIdentifiers("http://ehr.acme.org/identifiers/collections").head.head == "23234352356")
+    assert(specimen.subject.get.findId().get == "example")
+    assert(specimen.identifier.get.length == 1)
+    assert(specimen.identifier.get.head.value.get == "23234352356")
+    assert(specimen.identifier.get.head.system.get == "http://ehr.acme.org/identifiers/collections")
+    assert(specimen.`type`.get.coding.get.head.code.get == "122555007")
+    assert(specimen.`type`.get.coding.get.head.system.get == "http://snomed.info/sct")
+    assert(specimen.`type`.get.coding.get.head.display.get == "Venous blood specimen")
   }
 
   test("Test Condition") {
@@ -37,18 +44,18 @@ class TestSuite extends FunSuite {
     assert(resource.clinicalStatus.get.toString == ClinicalStatus.active.toString)
     assert(resource.verificationStatus.get == "confirmed")
     assert(resource.subject.get.reference.get == "Patient/example")
-    assert(resource.subject.get.findId.get == "example")
+    assert(resource.subject.get.findId().get == "example")
     assert(resource.onsetDateTime.map(d => d.getYear).getOrElse(Assert.fail()) == 2012)
   }
 
-  test("Test Condition witn uuid urn subject reference") {
+  test("Test Condition with uuid urn subject reference") {
     val json = scala.io.Source.fromFile(getClass.getResource("/ConditionUuid.test.json").getFile).mkString
     val resource = Deserializer.loadFhirResource(json).asInstanceOf[Condition]
 
     assert(resource.id.get == "example")
     assert(resource.clinicalStatus.get.toString == ClinicalStatus.active.toString)
     assert(resource.verificationStatus.get == "confirmed")
-    assert(resource.subject.get.findId.get == "f7fd3fc5-b34e-42dc-bd39-da51cdc136df")
+    assert(resource.subject.get.findId().get == "f7fd3fc5-b34e-42dc-bd39-da51cdc136df")
     assert(resource.onsetDateTime.map(d => d.getYear).getOrElse(Assert.fail()) == 2012)
   }
 
@@ -80,7 +87,7 @@ class TestSuite extends FunSuite {
     assert(resource.code.get.coding.get.head.code.get == "80146002")
     assert(resource.code.get.coding.get.head.display.get == "Appendectomy (Procedure)")
     assert(resource.code.get.text.get == "Appendectomy")
-    assert(resource.subject.get.findId.get == "example")
+    assert(resource.subject.get.findId().get == "example")
     assert(resource.performedDateTime.map(d => d.format(DateTimeFormatter.ofPattern( "yyyy-MM-dd"))).getOrElse(Assert.fail()) == "2013-04-05")
     assert(resource.performedPeriod.isEmpty)
     assert(resource.note.get.head.text.get == "Routine Appendectomy. Appendix was inflamed and in retro-caecal position")
@@ -142,7 +149,7 @@ class TestSuite extends FunSuite {
   }
 
 
-  def testPatient(res: String) = {
+  private def testPatient(res: String) = {
     val json = scala.io.Source.fromFile(getClass.getResource(res).getFile).mkString
     val patient = Deserializer.loadFhirResource(json).asInstanceOf[Patient]
 
@@ -151,8 +158,8 @@ class TestSuite extends FunSuite {
     assert(patient.birthDate.map(d => d.getMonthValue).getOrElse(Assert.fail()) == 5)
     assert(patient.birthDate.map(d => d.getDayOfMonth).getOrElse(Assert.fail()) == 7)
     val uri = new java.net.URI(patient.meta.orNull.tag.get.head.system.get)
-    assert(uri.getHost() == "lifeomic.com")
-    assert(uri.getPath() == "/fhir/dataset")
+    assert(uri.getHost == "lifeomic.com")
+    assert(uri.getPath == "/fhir/dataset")
 
     assert(patient.findCurrentAge().get >= 25)
   }


### PR DESCRIPTION
These changes upgrade json4s to version 3.5.3. The upgrade is being done to make this module compatible with versions of Spark >= 2.4.0.

Changes in json4s 3.5 introduced some breaking changes which required additional serializers to address. There are two behaviors which now require additional serializers to preserve.

1. There is a circular reference between the `Reference` and `Identifier` case classes. In json4s versions >= 3.5 if an instance of either class is empty json4s will enter an infinite loop of recursive deserialization calls.

2. In versions of json4s < 3.5 it was possible to deserialize a single-element array into a single-value field. This is the same behavior as the jackson [UNWRAP_SINGLE_VALUE_ARRAYS](https://github.com/FasterXML/jackson-databind/wiki/Deserialization-Features#structural-conversions). In json4s versions >= 3.5, single-value fields will be None if attempting to accept a single-value array. Additional serializers have been added to detect these cases.